### PR TITLE
Adds active model serializers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.0'
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'rack-cors', require: 'rack/cors'
+gem 'active_model_serializers'
 
 group :development, :test do
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.12)
+      actionpack (>= 4.1, < 6.2)
+      activemodel (>= 4.1, < 6.2)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.1.3.2)
       activesupport (= 6.1.3.2)
       globalid (>= 0.3.6)
@@ -63,6 +68,8 @@ GEM
     bootsnap (1.7.5)
       msgpack (~> 1.0)
     builder (3.2.4)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     coveralls (0.8.23)
@@ -86,6 +93,7 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
+    jsonapi-renderer (0.2.2)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -198,6 +206,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.4.4)
   coveralls
   factory_bot_rails

--- a/app/controllers/api/inquiries_controller.rb
+++ b/app/controllers/api/inquiries_controller.rb
@@ -3,7 +3,7 @@ class Api::InquiriesController < ApplicationController
     inquiry = Inquiry.create(inquiry_params)
 
     if inquiry.persisted? 
-      render json: { message: 'Thanks for your answers! We\'ll be in touch' }, status: 200
+      render json: { message: 'Thanks for your answers! We\'ll be in touch' }
     else 
       render json: { error_message: 'Unfortunately, we had a small issue processing your request. Would you please try again?' }, status: 422
     end
@@ -11,7 +11,7 @@ class Api::InquiriesController < ApplicationController
 
   def index
     inquiries = Inquiry.all
-    render json: {inquiries: inquiries}, status: 200
+    render json: inquiries, each_serializer: InquiriesIndexSerializer
   end
 
   private

--- a/app/serializers/inquiries_index_serializer.rb
+++ b/app/serializers/inquiries_index_serializer.rb
@@ -1,0 +1,7 @@
+class InquiriesIndexSerializer < ActiveModel::Serializer
+  attributes :id, :company, :size, :email, :phone, :office_type, :peers, :flexible, :locations, :start_date, :inquiry_date
+
+  def inquiry_date
+    object.created_at.strftime("%d %b %Y")
+  end
+end

--- a/config/initializers/ams.rb
+++ b/config/initializers/ams.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :json

--- a/spec/requests/api/api_can_respond_with_list_of_inquiries_spec.rb
+++ b/spec/requests/api/api_can_respond_with_list_of_inquiries_spec.rb
@@ -44,5 +44,9 @@ RSpec.describe 'GET /api/inquiries', type: :request do
     it 'is expected to include the inquiry\'s phone number' do
       expect(response_json['inquiries'].first['phone']).to eq 0707123456 
     end
+
+    it 'is expected to include the inquiry\'s created date' do
+      expect(response_json['inquiries'].first['inquiry_date']).to eq Time.zone.now().strftime("%d %b %Y")
+    end
   end
 end


### PR DESCRIPTION
[PT Story](https://www.pivotaltracker.com/story/show/178424029)

## User story:
```
As an API 
In order to respond with a readable created_at date
I want to format the date response
```

## Changes proposed
- Adds active model serializer gem
- Adds serialization to Inquiry index action
- Serializes inquiry_date