### PR TITLE
Brokers can set status attribute on Inquiries

### DIFF
--- a/app/controllers/api/inquiries_controller.rb
+++ b/app/controllers/api/inquiries_controller.rb
@@ -1,12 +1,12 @@
 class Api::InquiriesController < ApplicationController
-
   def create
     inquiry = Inquiry.create(inquiry_params)
 
-    if inquiry.persisted? 
+    if inquiry.persisted?
       render json: { message: 'Thanks for your answers! We\'ll be in touch' }
-    else 
-      render json: { error_message: 'Unfortunately, we had a small issue processing your request. Would you please try again?' }, status: 422
+    else
+      render json: { error_message: 'Unfortunately, we had a small issue processing your request. Would you please try again?' },
+             status: 422
     end
   end
 
@@ -18,12 +18,13 @@ class Api::InquiriesController < ApplicationController
   def update
     inquiry = Inquiry.find(params[:id])
     inquiry.update(inquiry_status: params[:form_data][:inquiry_status])
-    render json: { inquiry: inquiry, message:'Inquiry has been updated'}
+    render json: { inquiry: inquiry, message: 'Inquiry has been updated' }
   end
 
   private
 
   def inquiry_params
-    params.require(:form_data).permit(:size, :office_type, :inquiry_status, :company, :peers, :email, :flexible, :phone, locations: [])
+    params.require(:form_data).permit(:size, :office_type, :inquiry_status, :company, :peers, :email, :flexible,
+                                      :phone, locations: [])
   end
 end

--- a/app/controllers/api/inquiries_controller.rb
+++ b/app/controllers/api/inquiries_controller.rb
@@ -18,7 +18,11 @@ class Api::InquiriesController < ApplicationController
   def update
     inquiry = Inquiry.find(params[:id])
     inquiry.update(inquiry_status: params[:form_data][:inquiry_status])
-    render json: { inquiry: inquiry, message: 'Inquiry has been updated' }
+    if params[:inquiry_status]
+      render json: { inquiry: inquiry, message: 'Inquiry has been updated' }, status: 200
+    else
+      render json: { message: 'Inquiry has not been updated' }, status: 422
+    end
   end
 
   private

--- a/app/controllers/api/inquiries_controller.rb
+++ b/app/controllers/api/inquiries_controller.rb
@@ -17,6 +17,6 @@ class Api::InquiriesController < ApplicationController
   private
 
   def inquiry_params
-    params.require(:form_data).permit(:size, :office_type, :company, :peers, :email, :flexible, :phone, locations: [])
+    params.require(:form_data).permit(:size, :office_type, :inquiry_status, :company, :peers, :email, :flexible, :phone, locations: [])
   end
 end

--- a/app/controllers/api/inquiries_controller.rb
+++ b/app/controllers/api/inquiries_controller.rb
@@ -17,12 +17,10 @@ class Api::InquiriesController < ApplicationController
 
   def update
     inquiry = Inquiry.find(params[:id])
-    inquiry.update(inquiry_status: params[:form_data][:inquiry_status])
-    if params[:inquiry_status]
-      render json: { inquiry: inquiry, message: 'Inquiry has been updated' }, status: 200
-    else
-      render json: { message: 'Inquiry has not been updated' }, status: 422
-    end
+    update_inquiry = inquiry.update(inquiry_status: params[:form_data][:inquiry_status])
+    render json: { inquiry: inquiry, message: 'Inquiry has been updated' }, status: 200
+  rescue ArgumentError => e
+    render json: { message: e.message }, status: 422
   end
 
   private

--- a/app/controllers/api/inquiries_controller.rb
+++ b/app/controllers/api/inquiries_controller.rb
@@ -1,4 +1,5 @@
 class Api::InquiriesController < ApplicationController
+
   def create
     inquiry = Inquiry.create(inquiry_params)
 
@@ -12,6 +13,12 @@ class Api::InquiriesController < ApplicationController
   def index
     inquiries = Inquiry.all
     render json: inquiries, each_serializer: InquiriesIndexSerializer
+  end
+
+  def update
+    inquiry = Inquiry.find(params[:id])
+    inquiry.update(inquiry_status: params[:form_data][:inquiry_status])
+    render json: { inquiry: inquiry, message:'Inquiry has been updated'}
   end
 
   private

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -1,4 +1,5 @@
 class Inquiry < ApplicationRecord
   validates_presence_of :email
   enum office_type: {office: 1, open_space: 2}
+  enum inquiry_status: {pending: 1, started: 2, done: 3}
 end

--- a/app/serializers/inquiries_index_serializer.rb
+++ b/app/serializers/inquiries_index_serializer.rb
@@ -1,5 +1,5 @@
 class InquiriesIndexSerializer < ActiveModel::Serializer
-  attributes :id, :company, :size, :email, :phone, :office_type, :peers, :flexible, :locations, :start_date, :inquiry_date
+  attributes :id, :company, :size, :email, :phone, :office_type, :inquiry_status, :peers, :flexible, :locations, :start_date, :inquiry_date
 
   def inquiry_date
     object.created_at.strftime("%d %b %Y")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   namespace :api do
-    resources :inquiries, only: [:create, :index]
+    resources :inquiries, only: [:create, :index, :update]
   end
 end

--- a/db/migrate/20210607182009_add_status_to_inquiries.rb
+++ b/db/migrate/20210607182009_add_status_to_inquiries.rb
@@ -1,0 +1,5 @@
+class AddStatusToInquiries < ActiveRecord::Migration[6.1]
+  def change
+    add_column :inquiries, :inquiry_status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_06_113418) do
+ActiveRecord::Schema.define(version: 2021_06_07_182009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2021_06_06_113418) do
     t.string "locations", array: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "inquiry_status"
   end
 
 end

--- a/spec/factories/inquiries.rb
+++ b/spec/factories/inquiries.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :inquiry do
     size { 5 }
     office_type { 1 }
+    inquiry_status { 1 }
     company { "Company" }
     peers { true }
     email { "mrfake@fake.com" }

--- a/spec/models/inquiry_spec.rb
+++ b/spec/models/inquiry_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Inquiry, type: :model do
     it { is_expected.to have_db_column(:flexible).of_type(:boolean) }
     it { is_expected.to have_db_column(:phone).of_type(:integer) }
     it { is_expected.to have_db_column(:start_date).of_type(:string) }
+    it { is_expected.to have_db_column(:inquiry_status).of_type(:integer) }
     it 'is expected to have db column locations of type array' do
       expect(subject[:locations]).kind_of?(Array)
     end
@@ -19,6 +20,10 @@ RSpec.describe Inquiry, type: :model do
 
   describe 'Office type' do
     it { is_expected.to define_enum_for(:office_type).with_values({ office: 1, open_space: 2}) }
+  end
+
+  describe 'Inquiry status' do
+    it { is_expected.to define_enum_for(:inquiry_status).with_values({ pending: 1, started: 2, done: 3}) }
   end
 
   describe 'Factory' do

--- a/spec/requests/api/api_can_respond_with_list_of_inquiries_spec.rb
+++ b/spec/requests/api/api_can_respond_with_list_of_inquiries_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe 'GET /api/inquiries', type: :request do
       expect(response_json['inquiries'].first['office_type']).to eq 'office' 
     end
 
+    it 'is expected to include the inquiry\'s status type' do
+      expect(response_json['inquiries'].first['inquiry_status']).to eq 'pending' 
+    end
+
     it 'is expected to include the inquiry\'s company name' do
       expect(response_json['inquiries'].first['company']).to eq 'Company'
     end

--- a/spec/requests/api/provider_can_update_inquiry_spec.rb
+++ b/spec/requests/api/provider_can_update_inquiry_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'PUT /api/inquiries/:id', type: :request do
-  let!(:inquiry) {create(:inquiry, inquiry_status: 'pending')}
-  describe 'successfully' do
+  let!(:inquiry) { create(:inquiry, inquiry_status: 'pending') }
+  describe 'successfully updated' do
     before do
       put "/api/inquiries/#{inquiry.id}",
           params: {

--- a/spec/requests/api/provider_can_update_inquiry_spec.rb
+++ b/spec/requests/api/provider_can_update_inquiry_spec.rb
@@ -20,4 +20,21 @@ RSpec.describe 'PUT /api/inquiries/:id', type: :request do
       expect(response_json['inquiry']['inquiry_status']).to eq 'started'
     end
   end
+
+  describe 'unsuccessfully updated with wrong params' do
+    before do
+      put "/api/inquiries/#{inquiry.id}",
+          params: {
+            form_data: { inquiry_status: '' }
+          }
+    end
+
+    it 'is expected to return a 422 status' do
+      expect(response).to have_http_status 422
+    end
+
+    it 'is expected to return error message' do
+      expect(response_json['message']).to eq 'Inquiry has not been updated'
+    end
+  end
 end

--- a/spec/requests/api/provider_can_update_inquiry_spec.rb
+++ b/spec/requests/api/provider_can_update_inquiry_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe 'PUT /api/inquiries/:id', type: :request do
+  let!(:inquiry) {create(:inquiry, inquiry_status: 'pending')}
+  describe 'successfully' do
+    before do
+      put "/api/inquiries/#{inquiry.id}",
+          params: {
+            form_data: { inquiry_status: 'started' }
+          }
+    end
+
+    it 'is expected to return a 200 status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to respond with a message' do
+      expect(response_json['message']).to eq 'Inquiry has been updated'
+    end
+
+    it 'is expected to set inquiry status to started' do
+      expect(response_json['inquiry']['inquiry_status']).to eq 'started'
+    end
+  end
+end

--- a/spec/requests/api/provider_can_update_inquiry_spec.rb
+++ b/spec/requests/api/provider_can_update_inquiry_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'PUT /api/inquiries/:id', type: :request do
     before do
       put "/api/inquiries/#{inquiry.id}",
           params: {
-            form_data: { inquiry_status: '' }
+            form_data: { inquiry_status: 'Your mom' }
           }
     end
 
@@ -34,7 +34,7 @@ RSpec.describe 'PUT /api/inquiries/:id', type: :request do
     end
 
     it 'is expected to return error message' do
-      expect(response_json['message']).to eq 'Inquiry has not been updated'
+      expect(response_json['message']).to eq "'Your mom' is not a valid inquiry_status"
     end
   end
 end

--- a/spec/requests/api/visitors_can_create_inquiries_spec.rb
+++ b/spec/requests/api/visitors_can_create_inquiries_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe 'POST /api/inquiries', type: :request do
              form_data: {
                size: 1,
                office_type: 'office',
+               inquiry_status: 'pending',
                company: 'Craft',
                peers: true,
                email: 'example@example.com',
                flexible: true,
-               phone: 0o707123456,
+               phone: 0707123456,
                locations: ['Gothenburg City', 'Southside'],
                start_date: '2021-06-21'
              }
@@ -37,11 +38,12 @@ RSpec.describe 'POST /api/inquiries', type: :request do
              form_data: {
                size: 1,
                office_type: 'office',
+               inquiry_status: 'pending',
                company: 'Craft',
                peers: true,
                email: '',
                flexible: true,
-               phone: 0o707123456,
+               phone: 0707123456,
                locations: ['Gothenburg City', 'Southside'],
                start_date: '2021-06-21'
              }


### PR DESCRIPTION
PT https://www.pivotaltracker.com/story/show/178434414

### User story
```
As a broker
in order to keep track of my clients
I want to be able to change there current status
```

### Changes proposed
- Broker can update inquiries
