### PR TITLE
Broker can add a manual note to inquiry

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -2,15 +2,20 @@ class Api::NotesController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    inquiry = Inquiry.find(params[:inquiry_id])
+    begin
+      inquiry = Inquiry.find(params[:inquiry_id])
 
-    note = inquiry.notes.create(note_params.merge(writer: current_user))
-
-    if note.persisted?
-      render json: { message: 'Note successfully created' }
-    else
-      render json: { error_message: 'Unfortunately, we had a small issue processing your request. Would you please try again?' },
-             status: 422
+      note = inquiry.notes.create(note_params.merge(writer: current_user))
+  
+      if note.persisted?
+        render json: { message: 'Note successfully created' }
+      else
+        render json: { error_message: 'Unfortunately, we had a small issue processing your request. Would you please try again?' },
+               status: 422
+      end  
+    rescue => error
+      render json: { error_message: error.message },
+               status: 422
     end
   end
 

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -2,21 +2,18 @@ class Api::NotesController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    begin
-      inquiry = Inquiry.find(params[:inquiry_id])
+    inquiry = Inquiry.find(params[:inquiry_id])
 
-      note = inquiry.notes.create(note_params.merge(writer: current_user))
-  
-      if note.persisted?
-        render json: { message: 'Note successfully created' }
-      else
-        render json: { error_message: 'Unfortunately, we had a small issue processing your request. Would you please try again?' },
-               status: 422
-      end  
-    rescue => error
-      render json: { error_message: error.message },
-               status: 422
-    end
+    note = inquiry.notes.create(note_params.merge(creator: current_user))
+
+    if note.persisted?
+      render json: { message: 'Note successfully created' }
+    else
+      render json: { error_message: 'Unfortunately, we had a small issue processing your request. Would you please try again?' },
+              status: 422
+    end  
+  rescue => error
+    render json: { error_message: error.message }, status: 422
   end
 
   private 

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -1,0 +1,4 @@
+class Api::NotesController < ApplicationController
+  def create
+  end
+end

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -1,4 +1,15 @@
 class Api::NotesController < ApplicationController
+  before_action :authenticate_user!
+
   def create
+    inquiry = Inquiry.find(params[:inquiry_id])
+
+    note = current_user.notes.create(note_params).merge(inquiry: inquiry)
+
+    if note.persisted?
+      render json: { message: 'Note successfully created' }
+    else
+      binding.pry
+    end
   end
 end

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -9,7 +9,8 @@ class Api::NotesController < ApplicationController
     if note.persisted?
       render json: { message: 'Note successfully created' }
     else
-      binding.pry
+      render json: { error_message: 'Unfortunately, we had a small issue processing your request. Would you please try again?' },
+             status: 422
     end
   end
 

--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -4,12 +4,18 @@ class Api::NotesController < ApplicationController
   def create
     inquiry = Inquiry.find(params[:inquiry_id])
 
-    note = current_user.notes.create(note_params).merge(inquiry: inquiry)
+    note = inquiry.notes.create(note_params.merge(writer: current_user))
 
     if note.persisted?
       render json: { message: 'Note successfully created' }
     else
       binding.pry
     end
+  end
+
+  private 
+
+  def note_params
+    params.require(:note).permit(:body)
   end
 end

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -8,7 +8,6 @@ class Inquiry < ApplicationRecord
     event :start do
       transitions from: :pending, to: :started do
         guard do
-          self.save
           add_note("This is inquiry was started #{self.updated_at.strftime("%d %b %Y")}")
         end
       end
@@ -17,7 +16,6 @@ class Inquiry < ApplicationRecord
     event :finish do
       transitions from: :started, to: :done do
         guard do
-          self.save
           add_note("This is inquiry was finished #{self.updated_at.strftime("%d %b %Y")}")
         end
       end
@@ -26,7 +24,6 @@ class Inquiry < ApplicationRecord
     event :set_to_pending do
       transitions from: :started, to: :pending do
         guard do
-          self.save
           add_note("This is inquiry was shelved #{self.updated_at.strftime("%d %b %Y")}")
         end
       end

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -47,10 +47,10 @@ class Inquiry < ApplicationRecord
   private
 
   def add_note(body)
-    if broker && self.notes != []
+    if self.broker && self.notes != []
       self.notes.create(
         body: body,
-        creator_id: broker_id
+        creator: self.broker
       )   
     else
       self.notes.create(

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -8,6 +8,7 @@ class Inquiry < ApplicationRecord
     event :start do
       transitions from: :pending, to: :started do
         guard do
+          self.save
           add_note("This is inquiry was started #{self.updated_at.strftime("%d %b %Y")}")
         end
       end
@@ -16,6 +17,7 @@ class Inquiry < ApplicationRecord
     event :finish do
       transitions from: :started, to: :done do
         guard do
+          self.save
           add_note("This is inquiry was finished #{self.updated_at.strftime("%d %b %Y")}")
         end
       end
@@ -24,6 +26,7 @@ class Inquiry < ApplicationRecord
     event :set_to_pending do
       transitions from: :started, to: :pending do
         guard do
+          self.save
           add_note("This is inquiry was shelved #{self.updated_at.strftime("%d %b %Y")}")
         end
       end
@@ -47,9 +50,16 @@ class Inquiry < ApplicationRecord
   private
 
   def add_note(body)
-    self.notes.create(
-      body: body
-    )
+    if broker && self.notes != []
+      self.notes.create(
+        body: body,
+        creator_id: broker_id
+      )   
+    else
+      self.notes.create(
+        body: body
+      )
+    end
   end
 
   def send_notifications

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -2,5 +2,5 @@ class Note < ApplicationRecord
   validates_presence_of :body
 
   belongs_to :inquiry
-  belongs_to :writer, class_name: 'User', optional: true
+  belongs_to :creator, class_name: 'User', optional: true
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -2,4 +2,5 @@ class Note < ApplicationRecord
   validates_presence_of :body
 
   belongs_to :inquiry
+  belongs_to :writer, class_name: 'User', optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
+
+  has_many :notes
 end

--- a/app/serializers/notes/serializer.rb
+++ b/app/serializers/notes/serializer.rb
@@ -1,7 +1,12 @@
 class Notes::Serializer < ActiveModel::Serializer
-  attributes :body, :id, :date
+  attributes :body, :id, :date, :creator
 
   def date
     object.created_at.strftime("%d %b %Y")
+  end
+
+  def creator
+    return 'System' unless object.creator
+    Users::Serializer.new(object.creator)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
-    resources :inquiries, only: %i[create index update]
+    resources :inquiries, only: %i[create index update] do
+      resources :notes, only: :create
+    end
   end
 end

--- a/db/migrate/20210611131523_add_creator_to_notes.rb
+++ b/db/migrate/20210611131523_add_creator_to_notes.rb
@@ -1,0 +1,5 @@
+class AddCreatorToNotes < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :notes, :creator, null: true, foreign_key: { to_table: :users }
+  end
+end

--- a/db/migrate/20210611131523_add_writer_to_notes.rb
+++ b/db/migrate/20210611131523_add_writer_to_notes.rb
@@ -1,5 +1,0 @@
-class AddWriterToNotes < ActiveRecord::Migration[6.1]
-  def change
-    add_reference :notes, :writer, null: true, foreign_key: { to_table: :users }
-  end
-end

--- a/db/migrate/20210611131523_add_writer_to_notes.rb
+++ b/db/migrate/20210611131523_add_writer_to_notes.rb
@@ -1,5 +1,5 @@
 class AddWriterToNotes < ActiveRecord::Migration[6.1]
   def change
-    add_reference :inquiries, :writer, null: true, foreign_key: { to_table: :users }
+    add_reference :notes, :writer, null: true, foreign_key: { to_table: :users }
   end
 end

--- a/db/migrate/20210611131523_add_writer_to_notes.rb
+++ b/db/migrate/20210611131523_add_writer_to_notes.rb
@@ -1,0 +1,5 @@
+class AddWriterToNotes < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :inquiries, :writer, null: true, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,9 +37,9 @@ ActiveRecord::Schema.define(version: 2021_06_11_131523) do
     t.bigint "inquiry_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "writer_id"
+    t.bigint "creator_id"
+    t.index ["creator_id"], name: "index_notes_on_creator_id"
     t.index ["inquiry_id"], name: "index_notes_on_inquiry_id"
-    t.index ["writer_id"], name: "index_notes_on_writer_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -71,5 +71,5 @@ ActiveRecord::Schema.define(version: 2021_06_11_131523) do
   end
 
   add_foreign_key "inquiries", "users", column: "broker_id"
-  add_foreign_key "notes", "users", column: "writer_id"
+  add_foreign_key "notes", "users", column: "creator_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_11_083309) do
+ActiveRecord::Schema.define(version: 2021_06_11_131523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,7 +29,9 @@ ActiveRecord::Schema.define(version: 2021_06_11_083309) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "inquiry_status"
     t.bigint "broker_id"
+    t.bigint "writer_id"
     t.index ["broker_id"], name: "index_inquiries_on_broker_id"
+    t.index ["writer_id"], name: "index_inquiries_on_writer_id"
   end
 
   create_table "notes", force: :cascade do |t|
@@ -69,4 +71,5 @@ ActiveRecord::Schema.define(version: 2021_06_11_083309) do
   end
 
   add_foreign_key "inquiries", "users", column: "broker_id"
+  add_foreign_key "inquiries", "users", column: "writer_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,9 +29,7 @@ ActiveRecord::Schema.define(version: 2021_06_11_131523) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "inquiry_status"
     t.bigint "broker_id"
-    t.bigint "writer_id"
     t.index ["broker_id"], name: "index_inquiries_on_broker_id"
-    t.index ["writer_id"], name: "index_inquiries_on_writer_id"
   end
 
   create_table "notes", force: :cascade do |t|
@@ -39,7 +37,9 @@ ActiveRecord::Schema.define(version: 2021_06_11_131523) do
     t.bigint "inquiry_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "writer_id"
     t.index ["inquiry_id"], name: "index_notes_on_inquiry_id"
+    t.index ["writer_id"], name: "index_notes_on_writer_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -71,5 +71,5 @@ ActiveRecord::Schema.define(version: 2021_06_11_131523) do
   end
 
   add_foreign_key "inquiries", "users", column: "broker_id"
-  add_foreign_key "inquiries", "users", column: "writer_id"
+  add_foreign_key "notes", "users", column: "writer_id"
 end

--- a/spec/requests/api/inquiries/create_spec.rb
+++ b/spec/requests/api/inquiries/create_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'POST /api/inquiries', type: :request do
       expect(response).to have_http_status 422
     end
 
-    it 'is expected to respond with a success message' do
+    it 'is expected to return error message' do
       expect(response_json['error_message']).to eq 'Unfortunately, we had a small issue processing your request. Would you please try again?'
     end
   end

--- a/spec/requests/api/inquiries/index_spec.rb
+++ b/spec/requests/api/inquiries/index_spec.rb
@@ -61,6 +61,10 @@ RSpec.describe 'GET /api/inquiries', type: :request do
         expect(response_json['inquiries'].first['notes'].first).to include "body"
       end
 
+      it 'with their creator' do
+        expect(response_json['inquiries'].first['notes'].first).to include "creator"
+      end
+
       it 'with their id' do
         expect(response_json['inquiries'].first['notes'].first).to include "id"
       end

--- a/spec/requests/api/inquiries_notes/create_spec.rb
+++ b/spec/requests/api/inquiries_notes/create_spec.rb
@@ -1,9 +1,19 @@
 RSpec.describe 'POST /api/inquiries/:id/notes', type: :request do
   let(:inquiry) { create(:inquiry, inquiry_status: 'pending') }
+  let(:writer) { create(:user) }
+  let(:credentials) { writer.create_new_auth_token }
+  let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
+
 
   describe 'successfully' do
     before do
-      post "/api/inquiries/#{inquiry.id}/notes"
+      post "/api/inquiries/#{inquiry.id}/notes",
+      params: {
+        note: {
+          body: 'Dont mention clients hairy nose'
+        }
+      },
+      headers: headers
     end
 
     it 'is expected to return a 200 status' do
@@ -12,6 +22,10 @@ RSpec.describe 'POST /api/inquiries/:id/notes', type: :request do
 
     it 'is expected to respond with a success message' do
       expect(response_json['message']).to eq 'Note successfully created'
+    end
+
+    it 'is expected to have note associated to user that submited it' do
+      expect(inquiry.notes.last.writer).to eq writer
     end
   end
 

--- a/spec/requests/api/inquiries_notes/create_spec.rb
+++ b/spec/requests/api/inquiries_notes/create_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe 'POST /api/inquiries/:id/notes', type: :request do
+  let(:inquiry) { create(:inquiry, inquiry_status: 'pending') }
+
+  describe 'successfully' do
+    before do
+      post "/api/inquiries/#{inquiry.id}/notes"
+    end
+
+    it 'is expected to return a 200 status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to respond with a success message' do
+      expect(response_json['message']).to eq 'Note successfully created'
+    end
+  end
+
+  # describe 'unsuccessfully' do
+  #   before do
+  #     post "/api/inquiries/#{inquiry.id}/notes"
+  #   end
+  # end
+end 

--- a/spec/requests/api/inquiries_notes/create_spec.rb
+++ b/spec/requests/api/inquiries_notes/create_spec.rb
@@ -1,9 +1,8 @@
 RSpec.describe 'POST /api/inquiries/:id/notes', type: :request do
   let(:inquiry) { create(:inquiry, inquiry_status: 'pending') }
-  let(:writer) { create(:user) }
-  let(:credentials) { writer.create_new_auth_token }
+  let(:creator) { create(:user) }
+  let(:credentials) { creator.create_new_auth_token }
   let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
-
 
   describe 'successfully' do
     before do
@@ -25,7 +24,7 @@ RSpec.describe 'POST /api/inquiries/:id/notes', type: :request do
     end
 
     it 'is expected to have note associated to user that submited it' do
-      expect(inquiry.notes.last.writer).to eq writer
+      expect(inquiry.notes.last.creator).to eq creator
     end
   end
 

--- a/spec/requests/api/inquiries_notes/create_spec.rb
+++ b/spec/requests/api/inquiries_notes/create_spec.rb
@@ -49,5 +49,25 @@ RSpec.describe 'POST /api/inquiries/:id/notes', type: :request do
           .to include 'You need to sign in or sign up before continuing.'
       end
     end
+
+    describe 'with invalid param' do
+      before do
+        post "/api/inquiries/#{inquiry.id}/notes",
+        params: {
+          note: {
+            body: ''
+          }
+        },
+        headers: headers
+      end
+
+      it 'is expected to return a 422 status' do
+        expect(response).to have_http_status 422
+      end
+  
+      it 'is expected to return error message' do
+        expect(response_json['error_message']).to eq 'Unfortunately, we had a small issue processing your request. Would you please try again?'
+      end  
+    end
   end
 end 

--- a/spec/requests/api/inquiries_notes/create_spec.rb
+++ b/spec/requests/api/inquiries_notes/create_spec.rb
@@ -69,5 +69,25 @@ RSpec.describe 'POST /api/inquiries/:id/notes', type: :request do
         expect(response_json['error_message']).to eq 'Unfortunately, we had a small issue processing your request. Would you please try again?'
       end  
     end
+
+    describe 'with wrong inquiry id' do
+      before do
+        post "/api/inquiries/420/notes",
+        params: {
+          note: {
+            body: 'Fake inquiry id in request'
+          }
+        },
+        headers: headers
+      end
+
+      it 'is expected to return a 422 status' do
+        expect(response).to have_http_status 422
+      end
+  
+      it 'is expected to return error message' do
+        expect(response_json['error_message']).to eq "Couldn't find Inquiry with 'id'=420"
+      end
+    end
   end
 end 

--- a/spec/requests/api/inquiries_notes/create_spec.rb
+++ b/spec/requests/api/inquiries_notes/create_spec.rb
@@ -29,9 +29,25 @@ RSpec.describe 'POST /api/inquiries/:id/notes', type: :request do
     end
   end
 
-  # describe 'unsuccessfully' do
-  #   before do
-  #     post "/api/inquiries/#{inquiry.id}/notes"
-  #   end
-  # end
+  describe 'unsuccessfull' do
+    describe 'without valid authentication' do
+      before do
+        post "/api/inquiries/#{inquiry.id}/notes",
+        params: {
+          note: {
+            body: 'Dont mention clients hairy nose'
+          }
+        }
+      end
+
+      it 'is expected to return a 401 status' do
+        expect(response).to have_http_status 401
+      end
+
+      it 'is expected to return error message' do
+        expect(response_json['errors'])
+          .to include 'You need to sign in or sign up before continuing.'
+      end
+    end
+  end
 end 


### PR DESCRIPTION
PT https://www.pivotaltracker.com/story/show/178498653
### User Story
```
As an API
In order to let brokers keep track of their activities
I would like to be able to attach a note to an inquiry
```
### Changes proposed 
- Adds a nested route `/api/inquiries/:id/notes` for manual creation of notes for specific inquiry
- Adds association between User and Note with `creator` foreign key
- In Note serializer creator will either be the broker or system
- Updates automatic notes from events to be created by broker that triggers them

### Packages/Gems added
No gems added

### What I have learned working on this feature
Nothing new here, just more associations and nested routes