### PR TITLE
API can send collections of analytics to the broker's dashboard

### DIFF
--- a/app/controllers/api/analytics_controller.rb
+++ b/app/controllers/api/analytics_controller.rb
@@ -1,0 +1,29 @@
+class Api::AnalyticsController < ApplicationController
+  before_action :get_statistics
+
+  def index 
+    binding.pry
+    render json: { statistics: @statistics }
+  end
+
+  private
+
+  def get_statistics
+    @statistics = {}
+    visits_stats
+    events_stats
+  end
+
+  def visits_stats
+   
+    @statistics[:visits] = {
+      total: Ahoy::Visit.count
+    }
+  end
+
+  def events_stats
+    @statistics[:events] = {
+      answer: Ahoy::Event.all.where(name: 'answer')
+    }
+  end
+end

--- a/app/controllers/api/analytics_controller.rb
+++ b/app/controllers/api/analytics_controller.rb
@@ -2,7 +2,6 @@ class Api::AnalyticsController < ApplicationController
   before_action :get_statistics
 
   def index 
-    binding.pry
     render json: { statistics: @statistics }
   end
 
@@ -15,7 +14,6 @@ class Api::AnalyticsController < ApplicationController
   end
 
   def visits_stats
-   
     @statistics[:visits] = {
       total: Ahoy::Visit.count
     }
@@ -23,7 +21,49 @@ class Api::AnalyticsController < ApplicationController
 
   def events_stats
     @statistics[:events] = {
-      answer: Ahoy::Event.all.where(name: 'answer')
+      answers: [
+        {
+          value: @statistics[:visits][:total],
+          name: 'total'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'size').count,
+          name: 'size'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'office_type').count,
+          name: 'office_type'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'email').count,
+          name: 'email'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'peers').count,
+          name: 'peers'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'locations').count,
+          name: 'locations'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'flexible').count,
+          name: 'flexible'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'start_date').count,
+          name: 'start_date'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'phone').count,
+          name: 'phone'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'submit').count,
+          name: 'submit'
+        },
+      ]
     }
+    @statistics[:events][:calls] = Ahoy::Event.where(name: 'phone_button').count
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,14 @@
 Rails.application.routes.draw do
+  namespace :api do
+    get 'analytics/index'
+  end
   mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
     mount Ahoy::Engine => "/ahoy"
     resources :inquiries, only: %i[create index update] do
       resources :notes, only: :create
     end
+    resources :analytics, only: :index
   end
 end
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,4 @@
 Rails.application.routes.draw do
-  namespace :api do
-    get 'analytics/index'
-  end
   mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
     mount Ahoy::Engine => "/ahoy"

--- a/spec/requests/api/analytics/analytics_providers_spec.rb
+++ b/spec/requests/api/analytics/analytics_providers_spec.rb
@@ -10,14 +10,6 @@ RSpec.describe 'GET, api/analytics', type: :request do
       screen_height: 1080,
       screen_width: 1920 }.to_json
   end
-  let(:visit_headers) do
-    {
-      'Ahoy-Visit': visit_token,
-      'Ahoy-Visitor': visitor_token,
-      'Content-Type': 'application/json',
-      'HTTP_USER_AGENT': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36'
-    }
-  end
   let(:wizard_event_data) do
     {
       visit_token: visit_token,
@@ -35,7 +27,6 @@ RSpec.describe 'GET, api/analytics', type: :request do
       ]
     }.to_json
   end
-
   let(:call_button_event_data) do
     {
       visit_token: visit_token,
@@ -48,13 +39,21 @@ RSpec.describe 'GET, api/analytics', type: :request do
       ]
     }.to_json
   end
+  let(:headers) do
+    {
+      'Ahoy-Visit': visit_token,
+      'Ahoy-Visitor': visitor_token,
+      'Content-Type': 'application/json',
+      'HTTP_USER_AGENT': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36'
+    }
+  end
 
   before do
-    post '/api/ahoy/visits', params: visit_data, headers: visit_headers
-    post '/api/ahoy/events', params: wizard_event_data, headers: visit_headers
-    post '/api/ahoy/events', params: wizard_event_data, headers: visit_headers
-    post '/api/ahoy/events', params: wizard_event_data, headers: visit_headers
-    post '/api/ahoy/events', params: call_button_event_data, headers: visit_headers
+    post '/api/ahoy/visits', params: visit_data, headers: headers
+    post '/api/ahoy/events', params: wizard_event_data, headers: headers 
+    post '/api/ahoy/events', params: wizard_event_data, headers: headers 
+    post '/api/ahoy/events', params: wizard_event_data, headers: headers 
+    post '/api/ahoy/events', params: call_button_event_data, headers: headers
   end
 
   before do

--- a/spec/requests/api/analytics/analytics_providers_spec.rb
+++ b/spec/requests/api/analytics/analytics_providers_spec.rb
@@ -18,10 +18,43 @@ RSpec.describe 'GET, api/analytics', type: :request do
       'HTTP_USER_AGENT': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36'
     }
   end
+  let(:wizard_event_data) do
+    {
+      visit_token: visit_token,
+      visitor_token: visitor_token,
+      events: [
+        {
+          name: 'answer',
+          properties: {
+            value: 4,
+            question: 'size',
+            size: 4
+          },
+          time: "2018-01-01T00:00:00-07:00"
+        }
+      ]
+    }.to_json
+  end
+
+  let(:call_button_event_data) do
+    {
+      visit_token: visit_token,
+      visitor_token: visitor_token,
+      events: [
+        {
+          name: 'phone_button',
+          time: "2018-01-01T00:00:00-07:00"
+        }
+      ]
+    }.to_json
+  end
 
   before do
     post '/api/ahoy/visits', params: visit_data, headers: visit_headers
-    post '/api/ahoy/events', 
+    post '/api/ahoy/events', params: wizard_event_data, headers: visit_headers
+    post '/api/ahoy/events', params: wizard_event_data, headers: visit_headers
+    post '/api/ahoy/events', params: wizard_event_data, headers: visit_headers
+    post '/api/ahoy/events', params: call_button_event_data, headers: visit_headers
   end
 
   before do
@@ -29,10 +62,19 @@ RSpec.describe 'GET, api/analytics', type: :request do
   end
 
   it 'is expected to return a total number of visits' do
-    expect(response_json['statistics']['events']['answers']).to eq 10
+    expect(response_json['statistics']['visits']['total']).to eq 1
   end
 
-  it 'is expected to respond with a list of events' do
-    expect(response_json['statistics']['events']['answers']).to eq ''
+  it 'is expected to respond with a list of data for each question in wizard' do
+    expect(response_json['statistics']['events']['answers'].count).to eq 10
+  end
+
+  it 'is expected to sort wizard answers in an appropriate format' do
+    expected_response = { "value" => 3, "name" => 'size' }
+    expect(response_json['statistics']['events']['answers'].second()).to eq expected_response
+  end
+
+  it 'is expected to respond with total number of phone button presses' do
+    expect(response_json['statistics']['events']['calls']).to eq 1
   end
 end

--- a/spec/requests/api/analytics/analytics_providers_spec.rb
+++ b/spec/requests/api/analytics/analytics_providers_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe 'GET, api/analytics', type: :request do
+  let(:visitor_token) { SecureRandom.uuid }
+  let(:visit_token) { SecureRandom.uuid }
+  let!(:inquiry) { 2.times { create(:inquiry) } }
+  let(:visit_data) do
+    { visit_token: visit_token,
+      visitor_token: visitor_token,
+      js: true,
+      platform: 'Web',
+      screen_height: 1080,
+      screen_width: 1920 }.to_json
+  end
+  let(:visit_headers) do
+    {
+      'Ahoy-Visit': visit_token,
+      'Ahoy-Visitor': visitor_token,
+      'Content-Type': 'application/json',
+      'HTTP_USER_AGENT': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36'
+    }
+  end
+
+  before do
+    post '/api/ahoy/visits', params: visit_data, headers: visit_headers
+    post '/api/ahoy/events', 
+  end
+
+  before do
+    get '/api/analytics'
+  end
+
+  it 'is expected to return a total number of visits' do
+    expect(response_json['statistics']['events']['answers']).to eq 10
+  end
+
+  it 'is expected to respond with a list of events' do
+    expect(response_json['statistics']['events']['answers']).to eq ''
+  end
+end

--- a/spec/requests/api/inquiries/create_spec.rb
+++ b/spec/requests/api/inquiries/create_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'POST /api/inquiries', type: :request do
+rRSpec.describe 'POST /api/inquiries', type: :request do
   describe 'successfully' do
     let(:mail_delivery) { ActionMailer::Base.deliveries }
 

--- a/spec/requests/api/inquiries/create_spec.rb
+++ b/spec/requests/api/inquiries/create_spec.rb
@@ -1,4 +1,4 @@
-rRSpec.describe 'POST /api/inquiries', type: :request do
+RSpec.describe 'POST /api/inquiries', type: :request do
   describe 'successfully' do
     let(:mail_delivery) { ActionMailer::Base.deliveries }
 


### PR DESCRIPTION
[PT Story](https://www.pivotaltracker.com/story/show/178433678)

## User story
```
As an API
In order to gain an overview of how visitors use our site
I'd like to be able to store analytics
```

## Changes proposed
- Adds endpoint for analytics
- Sends total visits, a list of answered questions, and phone button clicks with index action

