### PR TITLE
API can send collections of analytics to the broker's dashboard

### DIFF
--- a/app/controllers/api/analytics_controller.rb
+++ b/app/controllers/api/analytics_controller.rb
@@ -25,7 +25,7 @@ class Api::AnalyticsController < ApplicationController
       Hash[:name, answer_key, :value, Ahoy::Event.where_event('answer', question: answer_key).count]
     end
     answers_stats.unshift({ value: @statistics[:visits][:total],
-                           name: 'total' })
+                            name: 'total' })
     @statistics[:events] = {
       answers: answers_stats
     }

--- a/app/controllers/api/analytics_controller.rb
+++ b/app/controllers/api/analytics_controller.rb
@@ -1,0 +1,69 @@
+class Api::AnalyticsController < ApplicationController
+  before_action :get_statistics
+
+  def index 
+    render json: { statistics: @statistics }
+  end
+
+  private
+
+  def get_statistics
+    @statistics = {}
+    visits_stats
+    events_stats
+  end
+
+  def visits_stats
+    @statistics[:visits] = {
+      total: Ahoy::Visit.count
+    }
+  end
+
+  def events_stats
+    @statistics[:events] = {
+      answers: [
+        {
+          value: @statistics[:visits][:total],
+          name: 'total'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'size').count,
+          name: 'size'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'office_type').count,
+          name: 'office_type'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'email').count,
+          name: 'email'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'peers').count,
+          name: 'peers'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'locations').count,
+          name: 'locations'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'flexible').count,
+          name: 'flexible'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'start_date').count,
+          name: 'start_date'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'phone').count,
+          name: 'phone'
+        },
+        {
+          value: Ahoy::Event.where_event("answer", question: 'submit').count,
+          name: 'submit'
+        },
+      ]
+    }
+    @statistics[:events][:calls] = Ahoy::Event.where(name: 'phone_button').count
+  end
+end

--- a/app/controllers/api/analytics_controller.rb
+++ b/app/controllers/api/analytics_controller.rb
@@ -1,7 +1,7 @@
 class Api::AnalyticsController < ApplicationController
   before_action :get_statistics
 
-  def index 
+  def index
     render json: { statistics: @statistics }
   end
 
@@ -20,49 +20,14 @@ class Api::AnalyticsController < ApplicationController
   end
 
   def events_stats
+    answers = %w[size office_type email peers locations flexible start_date phone submit]
+    answers_stats = answers.map do |answer_key|
+      Hash[:name, answer_key, :value, Ahoy::Event.where_event('answer', question: answer_key).count]
+    end
+    answers_stats.push({ value: @statistics[:visits][:total],
+                           name: 'total' })
     @statistics[:events] = {
-      answers: [
-        {
-          value: @statistics[:visits][:total],
-          name: 'total'
-        },
-        {
-          value: Ahoy::Event.where_event("answer", question: 'size').count,
-          name: 'size'
-        },
-        {
-          value: Ahoy::Event.where_event("answer", question: 'office_type').count,
-          name: 'office_type'
-        },
-        {
-          value: Ahoy::Event.where_event("answer", question: 'email').count,
-          name: 'email'
-        },
-        {
-          value: Ahoy::Event.where_event("answer", question: 'peers').count,
-          name: 'peers'
-        },
-        {
-          value: Ahoy::Event.where_event("answer", question: 'locations').count,
-          name: 'locations'
-        },
-        {
-          value: Ahoy::Event.where_event("answer", question: 'flexible').count,
-          name: 'flexible'
-        },
-        {
-          value: Ahoy::Event.where_event("answer", question: 'start_date').count,
-          name: 'start_date'
-        },
-        {
-          value: Ahoy::Event.where_event("answer", question: 'phone').count,
-          name: 'phone'
-        },
-        {
-          value: Ahoy::Event.where_event("answer", question: 'submit').count,
-          name: 'submit'
-        },
-      ]
+      answers: answers_stats
     }
     @statistics[:events][:calls] = Ahoy::Event.where(name: 'phone_button').count
   end

--- a/app/controllers/api/analytics_controller.rb
+++ b/app/controllers/api/analytics_controller.rb
@@ -24,7 +24,7 @@ class Api::AnalyticsController < ApplicationController
     answers_stats = answers.map do |answer_key|
       Hash[:name, answer_key, :value, Ahoy::Event.where_event('answer', question: answer_key).count]
     end
-    answers_stats.push({ value: @statistics[:visits][:total],
+    answers_stats.unshift({ value: @statistics[:visits][:total],
                            name: 'total' })
     @statistics[:events] = {
       answers: answers_stats

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       resources :notes, only: :create
       resources :hub_spot, only: :create
     end
+    resources :analytics, only: :index
   end
 end
   

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,1 +1,8 @@
-# Take it away, Thomas!
+FactoryBot.define do
+  factory :ahoy_event, class: 'Ahoy::Event' do
+    visit factory: :ahoy_visit
+    name { 'answer' }
+    properties {}
+    time { DateTime.now.utc }
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,1 @@
+# Take it away, Thomas!

--- a/spec/factories/visits.rb
+++ b/spec/factories/visits.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :ahoy_visit, class: 'Ahoy::Visit' do
+    visit_token { SecureRandom.uuid }
+    visitor_token { SecureRandom.uuid }
+    ip { '121.0.0.2' }
+  end
+end

--- a/spec/requests/api/analytics/analytics_for_brokers_spec.rb
+++ b/spec/requests/api/analytics/analytics_for_brokers_spec.rb
@@ -1,0 +1,79 @@
+RSpec.describe 'GET, api/analytics', type: :request do
+  let(:visitor_token) { SecureRandom.uuid }
+  let(:visit_token) { SecureRandom.uuid }
+  let!(:inquiry) { 2.times { create(:inquiry) } }
+  let(:visit_data) do
+    { visit_token: visit_token,
+      visitor_token: visitor_token,
+      js: true,
+      platform: 'Web',
+      screen_height: 1080,
+      screen_width: 1920 }.to_json
+  end
+  let(:wizard_event_data) do
+    {
+      visit_token: visit_token,
+      visitor_token: visitor_token,
+      events: [
+        {
+          name: 'answer',
+          properties: {
+            value: 4,
+            question: 'size',
+            size: 4
+          },
+          time: "2018-01-01T00:00:00-07:00"
+        }
+      ]
+    }.to_json
+  end
+  let(:call_button_event_data) do
+    {
+      visit_token: visit_token,
+      visitor_token: visitor_token,
+      events: [
+        {
+          name: 'phone_button',
+          time: "2018-01-01T00:00:00-07:00"
+        }
+      ]
+    }.to_json
+  end
+  let(:headers) do
+    {
+      'Ahoy-Visit': visit_token,
+      'Ahoy-Visitor': visitor_token,
+      'Content-Type': 'application/json',
+      'HTTP_USER_AGENT': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36'
+    }
+  end
+
+  before do
+    post '/api/ahoy/visits', params: visit_data, headers: headers
+    post '/api/ahoy/events', params: wizard_event_data, headers: headers 
+    post '/api/ahoy/events', params: wizard_event_data, headers: headers 
+    post '/api/ahoy/events', params: wizard_event_data, headers: headers 
+    post '/api/ahoy/events', params: call_button_event_data, headers: headers
+  end
+
+  before do
+    get '/api/analytics'
+  end
+
+  it 'is expected to return a total number of visits' do
+    expect(response_json['statistics']['visits']['total']).to eq 1
+  end
+
+  it 'is expected to respond with a list of data for each question in wizard' do
+    expect(response_json['statistics']['events']['answers'].count).to eq 10
+  end
+
+  it 'is expected to sort wizard answers in an appropriate format' do
+    expected_response = { "value" => 3, "name" => 'size' }
+    expect(response_json['statistics']['events']['answers'].second()).to eq expected_response
+  end
+
+  it 'is expected to respond with total number of phone button presses' do
+    expect(response_json['statistics']['events']['calls']).to eq 1
+  end
+end

--- a/spec/requests/api/analytics/analytics_for_brokers_spec.rb
+++ b/spec/requests/api/analytics/analytics_for_brokers_spec.rb
@@ -35,13 +35,4 @@ RSpec.describe 'GET, api/analytics', type: :request do
   it 'is expected to respond with a list of data for each question in wizard' do
     expect(response_json['statistics']['events']['answers'].count).to eq 10
   end
-
-  it 'is expected to sort wizard answers in an appropriate format' do
-    expected_response = { 'value' => 2, 'name' => 'size' }
-    expect(response_json['statistics']['events']['answers'].first).to eq expected_response
-  end
-
-  it 'is expected to respond with total number of phone button presses' do
-    expect(response_json['statistics']['events']['calls']).to eq 1
-  end
 end

--- a/spec/requests/api/analytics/analytics_for_brokers_spec.rb
+++ b/spec/requests/api/analytics/analytics_for_brokers_spec.rb
@@ -35,4 +35,13 @@ RSpec.describe 'GET, api/analytics', type: :request do
   it 'is expected to respond with a list of data for each question in wizard' do
     expect(response_json['statistics']['events']['answers'].count).to eq 10
   end
+  
+  it 'is expected to sort wizard answers in an appropriate format' do
+    expected_response = { 'value' => 2, 'name' => 'size' }
+    expect(response_json['statistics']['events']['answers'].second).to eq expected_response
+  end
+
+  it 'is expected to respond with total number of phone button presses' do
+    expect(response_json['statistics']['events']['calls']).to eq 1
+  end
 end

--- a/spec/requests/api/analytics/analytics_for_brokers_spec.rb
+++ b/spec/requests/api/analytics/analytics_for_brokers_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'GET, api/analytics', type: :request do
 
   it 'is expected to sort wizard answers in an appropriate format' do
     expected_response = { 'value' => 2, 'name' => 'size' }
-    expect(response_json['statistics']['events']['answers'].second).to eq expected_response
+    expect(response_json['statistics']['events']['answers'].first).to eq expected_response
   end
 
   it 'is expected to respond with total number of phone button presses' do

--- a/spec/requests/api/analytics/analytics_for_brokers_spec.rb
+++ b/spec/requests/api/analytics/analytics_for_brokers_spec.rb
@@ -36,11 +36,10 @@ RSpec.describe 'GET, api/analytics', type: :request do
     expect(response_json['statistics']['events']['answers'].count).to eq 10
   end
 
-  # I'm not really clear on what you want to test for here....
-  # it 'is expected to sort wizard answers in an appropriate format' do
-  #   expected_response = { 'value' => 3, 'name' => 'size' }
-  #   expect(response_json['statistics']['events']['answers'].second).to eq expected_response
-  # end
+  it 'is expected to sort wizard answers in an appropriate format' do
+    expected_response = { 'value' => 2, 'name' => 'size' }
+    expect(response_json['statistics']['events']['answers'].second).to eq expected_response
+  end
 
   it 'is expected to respond with total number of phone button presses' do
     expect(response_json['statistics']['events']['calls']).to eq 1

--- a/spec/requests/api/analytics/analytics_for_brokers_spec.rb
+++ b/spec/requests/api/analytics/analytics_for_brokers_spec.rb
@@ -1,59 +1,27 @@
 RSpec.describe 'GET, api/analytics', type: :request do
-  let(:visitor_token) { SecureRandom.uuid }
-  let(:visit_token) { SecureRandom.uuid }
-  let!(:inquiry) { 2.times { create(:inquiry) } }
-  let(:visit_data) do
-    { visit_token: visit_token,
-      visitor_token: visitor_token,
-      js: true,
-      platform: 'Web',
-      screen_height: 1080,
-      screen_width: 1920 }.to_json
+  let(:visit_1) { create(:ahoy_visit) }
+  let(:visit_2) { create(:ahoy_visit) }
+  let!(:answer_event_1) do
+    create(:ahoy_event,
+           visit: visit_1,
+           properties: { size: '3', value: '3', question: 'size' })
   end
-  let(:wizard_event_data) do
-    {
-      visit_token: visit_token,
-      visitor_token: visitor_token,
-      events: [
-        {
-          name: 'answer',
-          properties: {
-            value: 4,
-            question: 'size',
-            size: 4
-          },
-          time: "2018-01-01T00:00:00-07:00"
-        }
-      ]
-    }.to_json
+  let!(:answer_event_2) do
+    create(:ahoy_event,
+           visit: visit_2,
+           properties: { size: '1', value: '1', question: 'size' })
   end
-  let(:call_button_event_data) do
-    {
-      visit_token: visit_token,
-      visitor_token: visitor_token,
-      events: [
-        {
-          name: 'phone_button',
-          time: "2018-01-01T00:00:00-07:00"
-        }
-      ]
-    }.to_json
-  end
-  let(:headers) do
-    {
-      'Ahoy-Visit': visit_token,
-      'Ahoy-Visitor': visitor_token,
-      'Content-Type': 'application/json',
-      'HTTP_USER_AGENT': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36'
-    }
+  let!(:answer_event_3) do
+    create(:ahoy_event,
+           visit: visit_2,
+           properties: { office_type: 'flex', value: 'flex', question: 'office_type' })
   end
 
-  before do
-    post '/api/ahoy/visits', params: visit_data, headers: headers
-    post '/api/ahoy/events', params: wizard_event_data, headers: headers 
-    post '/api/ahoy/events', params: wizard_event_data, headers: headers 
-    post '/api/ahoy/events', params: wizard_event_data, headers: headers 
-    post '/api/ahoy/events', params: call_button_event_data, headers: headers
+  let!(:call_event) do
+    create(:ahoy_event,
+           visit: visit_2,
+           name: 'phone_button',
+           time: DateTime.now.utc)
   end
 
   before do
@@ -61,17 +29,18 @@ RSpec.describe 'GET, api/analytics', type: :request do
   end
 
   it 'is expected to return a total number of visits' do
-    expect(response_json['statistics']['visits']['total']).to eq 1
+    expect(response_json['statistics']['visits']['total']).to eq 2
   end
 
   it 'is expected to respond with a list of data for each question in wizard' do
     expect(response_json['statistics']['events']['answers'].count).to eq 10
   end
 
-  it 'is expected to sort wizard answers in an appropriate format' do
-    expected_response = { "value" => 3, "name" => 'size' }
-    expect(response_json['statistics']['events']['answers'].second()).to eq expected_response
-  end
+  # I'm not really clear on what you want to test for here....
+  # it 'is expected to sort wizard answers in an appropriate format' do
+  #   expected_response = { 'value' => 3, 'name' => 'size' }
+  #   expect(response_json['statistics']['events']['answers'].second).to eq expected_response
+  # end
 
   it 'is expected to respond with total number of phone button presses' do
     expect(response_json['statistics']['events']['calls']).to eq 1


### PR DESCRIPTION
[PT Story](https://www.pivotaltracker.com/story/show/178433678)

## User story
```
As an API
In order to gain an overview of how visitors use our site
I'd like to be able to store analytics
```

## Changes proposed
- Adds endpoint for analytics
- Sends total visits, a list of answered questions, and phone button clicks with index action

