### PR TITLE
Send inquiry started by broker email

### DIFF
--- a/app/mailers/inquiry_mailer.rb
+++ b/app/mailers/inquiry_mailer.rb
@@ -13,7 +13,7 @@ class InquiryMailer < ApplicationMailer
   end
 
   def started_email(data)
-    inquiry = data
-    mail(to: inquiry.email, subject: "FlexCoast has started processing your inquiry")
+    @inquiry = data
+    mail(to: @inquiry.email, subject: "FlexCoast has started processing your inquiry")
   end
 end

--- a/app/mailers/inquiry_mailer.rb
+++ b/app/mailers/inquiry_mailer.rb
@@ -11,4 +11,9 @@ class InquiryMailer < ApplicationMailer
     inquiry = data
     mail(to: inquiry.email, subject: "FlexCost is on top of things!")
   end
+
+  def started_email(data)
+    inquiry = data
+    mail(to: inquiry.email, subject: "FlexCoast has started processing your inquiry")
+  end
 end

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -9,7 +9,11 @@ class Inquiry < ApplicationRecord
       transitions from: :pending, to: :started do
         guard do
           add_note("This is inquiry was started.")
-          InquiryMailer.started_email(self).deliver if Rails.env.test?
+          binding.pry
+          if !self.started_email_sent
+            InquiryMailer.started_email(self).deliver if Rails.env.test?
+            self.update(started_email_sent: true)
+          end
         end
       end
     end
@@ -41,6 +45,7 @@ class Inquiry < ApplicationRecord
   end
 
   def aasm_event_failed(event_name, old_state_name)
+    binding.pry
     raise StandardError, "You can't perform this on an inquiry that is '#{old_state_name}'"
   end
 

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -8,7 +8,7 @@ class Inquiry < ApplicationRecord
     event :start do
       transitions from: :pending, to: :started do
         guard do
-          add_note("This is inquiry was started.")
+          add_note("This inquiry was started.")
           send_started_notification()
         end
       end
@@ -17,7 +17,7 @@ class Inquiry < ApplicationRecord
     event :finish do
       transitions from: :started, to: :done do
         guard do
-          add_note("This is inquiry was finished.")
+          add_note("This inquiry was finished.")
         end
       end
     end
@@ -25,7 +25,7 @@ class Inquiry < ApplicationRecord
     event :set_to_pending do
       transitions from: :started, to: :pending do
         guard do
-          add_note("This is inquiry was shelved.")
+          add_note("This inquiry was shelved.")
         end
       end
     end
@@ -33,7 +33,7 @@ class Inquiry < ApplicationRecord
     event :set_to_started do
       transitions from: :done, to: :started do
         guard do
-          add_note("This is inquiry was not actually finished.")
+          add_note("This inquiry was not actually finished.")
         end
       end
     end
@@ -79,7 +79,7 @@ class Inquiry < ApplicationRecord
   end
 
   def send_notifications
-    add_note("This is inquiry was submitted.")
+    add_note("This inquiry was submitted.")
     NotificationService.new_inquiry(self)
   end
 end

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -9,11 +9,7 @@ class Inquiry < ApplicationRecord
       transitions from: :pending, to: :started do
         guard do
           add_note("This is inquiry was started.")
-          binding.pry
-          if !self.started_email_sent
-            InquiryMailer.started_email(self).deliver if Rails.env.test?
-            self.update(started_email_sent: true)
-          end
+          send_started_notification()
         end
       end
     end
@@ -45,7 +41,6 @@ class Inquiry < ApplicationRecord
   end
 
   def aasm_event_failed(event_name, old_state_name)
-    binding.pry
     raise StandardError, "You can't perform this on an inquiry that is '#{old_state_name}'"
   end
 
@@ -73,6 +68,13 @@ class Inquiry < ApplicationRecord
       self.notes.create(
         body: body
       )
+    end
+  end
+
+  def send_started_notification
+    unless self.started_email_sent
+      InquiryMailer.started_email(self).deliver if Rails.env.test?
+      self.update(started_email_sent: true)
     end
   end
 

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -9,6 +9,7 @@ class Inquiry < ApplicationRecord
       transitions from: :pending, to: :started do
         guard do
           add_note("This is inquiry was started.")
+          InquiryMailer.started_email(self).deliver if Rails.env.test?
         end
       end
     end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -6,12 +6,14 @@ module NotificationService
     InquiryMailer.broker_email(inquiry).deliver if Rails.env.test?
     InquiryMailer.submitter_email(inquiry).deliver if Rails.env.test?
 
-    client = SlackNotify::Client.new(
-      webhook_url: Rails.application.credentials.dig(:slack, :webhook_url)
-    )
-    client.notify(
-      "New Inquiry From #{inquiry.email} In Your Inbox", 
-      '#flex-coast-notify'
-    )
+    if Rails.env.production? || Rails.env.test?
+      client = SlackNotify::Client.new(
+        webhook_url: Rails.application.credentials.dig(:slack, :webhook_url)
+      )
+      client.notify(
+        "New Inquiry From #{inquiry.email} In Your Inbox", 
+        '#flex-coast-notify'
+      )
+    end
   end
 end

--- a/app/views/inquiry_mailer/started_email.html.erb
+++ b/app/views/inquiry_mailer/started_email.html.erb
@@ -5,7 +5,7 @@
   <body>
     <h1>Hello <%= @inquiry.email %></h1>
     <p>
-      I'm <%= @inquiry.broker.email %>, I have now started to work on your submission.
+      I'm <%= @inquiry.broker.name %>, I have now started to work on your submission.
       If you have any questions before I comeback to you. Then you can reach me on <%= @inquiry.broker.email %> or 031-123-4567
     </p>
   </body>

--- a/app/views/inquiry_mailer/started_email.html.erb
+++ b/app/views/inquiry_mailer/started_email.html.erb
@@ -6,7 +6,7 @@
     <h1>Hello <%= @inquiry.email %></h1>
     <p>
       I'm <%= @inquiry.broker.name %>, I have now started to work on your submission.
-      If you have any questions before I comeback to you. Then you can reach me on <%= @inquiry.broker.email %> or 031-123-4567
+      If you have any questions before I comeback to you. You can reach me on <%= @inquiry.broker.email %> or text/call me at 031-123-4567
     </p>
   </body>
 </html>

--- a/app/views/inquiry_mailer/started_email.html.erb
+++ b/app/views/inquiry_mailer/started_email.html.erb
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>We are trying to find you an office right now...idk</h1>
+  </body>
+</html>

--- a/app/views/inquiry_mailer/started_email.html.erb
+++ b/app/views/inquiry_mailer/started_email.html.erb
@@ -3,6 +3,10 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <h1>We are trying to find you an office right now...idk</h1>
+    <h1>Hello <%= @inquiry.email %></h1>
+    <p>
+      I'm <%= @inquiry.broker.email %>, I have now started to work on your submission.
+      If you have any questions before I comeback to you. Then you can reach me on <%= @inquiry.broker.email %> or 031-123-4567
+    </p>
   </body>
 </html>

--- a/app/views/inquiry_mailer/submitter_email.html.erb
+++ b/app/views/inquiry_mailer/submitter_email.html.erb
@@ -3,6 +3,9 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <h1>We received your inquiry and we have you covered! Our team will select the best offices for you, expect to hear from us withing a day or two. Meanwhile fell free to contact us, our phone is 031-123-4567</h1>
+    <h1>
+      We received your inquiry and we have you covered! Our team will select the best offices for you, expect to hear from us withing a day or two.
+    </h1>
+    <p>If you have any questions before I comeback to you. You can text or call me at 031-123-4567.</p>
   </body>
 </html>

--- a/db/migrate/20210618090920_add_started_email_sent_to_inquiries.rb
+++ b/db/migrate/20210618090920_add_started_email_sent_to_inquiries.rb
@@ -1,0 +1,5 @@
+class AddStartedEmailSentToInquiries < ActiveRecord::Migration[6.1]
+  def change
+    add_column :inquiries, :started_email_sent, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_16_162237) do
+ActiveRecord::Schema.define(version: 2021_06_18_090920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2021_06_16_162237) do
     t.integer "inquiry_status"
     t.bigint "broker_id"
     t.integer "start_date"
+    t.boolean "started_email_sent"
     t.index ["broker_id"], name: "index_inquiries_on_broker_id"
   end
 

--- a/spec/factories/inquiries.rb
+++ b/spec/factories/inquiries.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
     phone { '0707123456' }
     locations { %w[Nordstaden Avenyn] }
     start_date { 1 }
+    started_email_sent { false }
   end
 end

--- a/spec/models/inquiry_spec.rb
+++ b/spec/models/inquiry_spec.rb
@@ -1,64 +1,7 @@
 RSpec.describe Inquiry, type: :model do
   let!(:mail_delivery) { ActionMailer::Base.deliveries }
 
-  describe 'Inquiry status events' do
-    let(:pending_inquiry) { create(:inquiry, inquiry_status: 'pending') }
-    let(:started_inquiry) { create(:inquiry, inquiry_status: 'started') }
-    let(:done_inquiry) { create(:inquiry, inquiry_status: 'done') }
-
-    describe 'Pending inquiry' do
-      it 'is expected to be able to ":start' do
-        expect{
-          pending_inquiry.start
-        }
-        .not_to raise_error
-      end
-
-      it 'is expected to not be able to ":finish"' do
-        expect{
-          pending_inquiry.finish
-        }
-        .to raise_error(StandardError)
-        .with_message("You can't perform this on an inquiry that is 'pending'")
-      end
-    end
-
-    describe 'Started inquiry' do
-      it 'is expected to be able to ":set_to_pending"' do
-        expect{
-          started_inquiry.set_to_pending
-        }
-        .not_to raise_error
-      end
-
-      it 'is expected to be able to "finish"' do
-        expect{
-          started_inquiry.finish
-        }
-        .not_to raise_error
-      end
-    end
-
-    describe 'Done inquiry' do
-      it 'is expected to not be able to ":set_to_pending"' do
-        expect{
-          done_inquiry.set_to_pending
-        }
-        .to raise_error(StandardError)
-        .with_message("You can't perform this on an inquiry that is 'done'")
-      end
-
-      it 'is expected to not be able to ":start"' do
-        expect{
-          done_inquiry.start
-        }
-        .to raise_error(StandardError)
-        .with_message("You can't perform this on an inquiry that is 'done'")
-      end
-    end
-  end
-
-  describe 'db table' do
+  describe 'Db table' do
     it {
       is_expected.to have_db_column(:size)
         .of_type(:integer)
@@ -70,6 +13,10 @@ RSpec.describe Inquiry, type: :model do
     it {
       is_expected.to have_db_column(:flexible)
         .of_type(:integer)
+    }
+    it {
+      is_expected.to have_db_column(:started_email_sent)
+        .of_type(:boolean)
     }
     it {
       is_expected.to have_db_column(:peers)
@@ -137,6 +84,14 @@ RSpec.describe Inquiry, type: :model do
       expect { create(:inquiry) }
         .to change { mail_delivery.count }.from(0).to(2)
     end
+
+    it 'is expected to only send notification email of inquiry started once' do
+      inquiry = create(:inquiry)
+      inquiry.start
+      inquiry.set_to_pending
+      inquiry.start
+      binding.pry
+    end
   end
 
   describe 'Factory' do
@@ -144,4 +99,62 @@ RSpec.describe Inquiry, type: :model do
       expect(create(:inquiry)).to be_valid
     end
   end
+
+  describe 'Inquiry status events' do
+    let(:pending_inquiry) { create(:inquiry, inquiry_status: 'pending') }
+    let(:started_inquiry) { create(:inquiry, inquiry_status: 'started') }
+    let(:done_inquiry) { create(:inquiry, inquiry_status: 'done') }
+
+    describe 'Pending inquiry' do
+      it 'is expected to be able to ":start' do
+        expect{
+          pending_inquiry.start
+        }
+        .not_to raise_error
+      end
+
+      it 'is expected to not be able to ":finish"' do
+        expect{
+          pending_inquiry.finish
+        }
+        .to raise_error(StandardError)
+        .with_message("You can't perform this on an inquiry that is 'pending'")
+      end
+    end
+
+    describe 'Started inquiry' do
+      it 'is expected to be able to ":set_to_pending"' do
+        expect{
+          started_inquiry.set_to_pending
+        }
+        .not_to raise_error
+      end
+
+      it 'is expected to be able to "finish"' do
+        expect{
+          started_inquiry.finish
+        }
+        .not_to raise_error
+      end
+    end
+
+    describe 'Done inquiry' do
+      it 'is expected to not be able to ":set_to_pending"' do
+        expect{
+          done_inquiry.set_to_pending
+        }
+        .to raise_error(StandardError)
+        .with_message("You can't perform this on an inquiry that is 'done'")
+      end
+
+      it 'is expected to not be able to ":start"' do
+        expect{
+          done_inquiry.start
+        }
+        .to raise_error(StandardError)
+        .with_message("You can't perform this on an inquiry that is 'done'")
+      end
+    end
+  end
+
 end

--- a/spec/models/inquiry_spec.rb
+++ b/spec/models/inquiry_spec.rb
@@ -88,9 +88,14 @@ RSpec.describe Inquiry, type: :model do
     it 'is expected to only send notification email of inquiry started once' do
       inquiry = create(:inquiry)
       inquiry.start
+      inquiry.save
+      binding.pry
       inquiry.set_to_pending
+      inquiry.save
+      binding.pry
       inquiry.start
       binding.pry
+      expect(mail_delivery.count).to eq 2
     end
   end
 

--- a/spec/models/inquiry_spec.rb
+++ b/spec/models/inquiry_spec.rb
@@ -84,19 +84,6 @@ RSpec.describe Inquiry, type: :model do
       expect { create(:inquiry) }
         .to change { mail_delivery.count }.from(0).to(2)
     end
-
-    it 'is expected to only send notification email of inquiry started once' do
-      inquiry = create(:inquiry)
-      inquiry.start
-      inquiry.save
-      binding.pry
-      inquiry.set_to_pending
-      inquiry.save
-      binding.pry
-      inquiry.start
-      binding.pry
-      expect(mail_delivery.count).to eq 2
-    end
   end
 
   describe 'Factory' do
@@ -106,7 +93,7 @@ RSpec.describe Inquiry, type: :model do
   end
 
   describe 'Inquiry status events' do
-    let(:pending_inquiry) { create(:inquiry, inquiry_status: 'pending') }
+    let(:pending_inquiry) { create(:inquiry, inquiry_status: 'pending', broker: create(:user)) }
     let(:started_inquiry) { create(:inquiry, inquiry_status: 'started') }
     let(:done_inquiry) { create(:inquiry, inquiry_status: 'done') }
 

--- a/spec/requests/api/inquiries/create_spec.rb
+++ b/spec/requests/api/inquiries/create_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'POST /api/inquiries', type: :request do
       end
 
       it 'is expected to contain welcome message in body' do
-        expect(mail_delivery[1].body).to include("We received your inquiry and we have you covered! Our team will select the best offices for you, expect to hear from us withing a day or two. Meanwhile fell free to contact us, our phone is 031-123-4567")
+        expect(mail_delivery[1].body).to include("We received your inquiry and we have you covered! Our team will select the best offices for you, expect to hear from us withing a day or two.")
       end
     end
   end

--- a/spec/requests/api/inquiries/create_spec.rb
+++ b/spec/requests/api/inquiries/create_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'POST /api/inquiries', type: :request do
     end
 
     it 'is expected to create note associated to inquiry about when it got submited' do
-      expect(Inquiry.last.notes.last.body).to eq "This is inquiry was submitted."
+      expect(Inquiry.last.notes.last.body).to eq "This inquiry was submitted."
     end
 
     describe 'outgoing email to broker' do

--- a/spec/requests/api/inquiries/update_spec.rb
+++ b/spec/requests/api/inquiries/update_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'PUT /api/inquiries/:id', type: :request do
         end
   
         it 'is expected to contain message about broker started handling inquiry' do
-          expect(mail_delivery[2].body).to include("If you have any questions before I comeback to you. Then you can reach me on broker@flexcoast.com or 031-123-4567")
+          expect(mail_delivery[2].body).to include("If you have any questions before I comeback to you. You can reach me on broker@flexcoast.com or text/call me at 031-123-4567")
         end
       end
     end

--- a/spec/requests/api/inquiries/update_spec.rb
+++ b/spec/requests/api/inquiries/update_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'PUT /api/inquiries/:id', type: :request do
 
       it 'is expected to create associated note about when inquiry was started' do
         pending_inquiry.reload
-        expect(pending_inquiry.notes.last.body).to eq "This is inquiry was started."
+        expect(pending_inquiry.notes.last.body).to eq "This inquiry was started."
       end
 
       describe 'outgoing email to person that submitted inquiry' do
@@ -77,7 +77,7 @@ RSpec.describe 'PUT /api/inquiries/:id', type: :request do
 
       it 'is expected to create associated note about when inquiry was finished' do
         started_inquiry.reload
-        expect(started_inquiry.notes.last.body).to eq "This is inquiry was finished."
+        expect(started_inquiry.notes.last.body).to eq "This inquiry was finished."
       end
     end
 
@@ -107,7 +107,7 @@ RSpec.describe 'PUT /api/inquiries/:id', type: :request do
 
       it 'is expected to create associated note about when inquiry was set to started' do
         done_inquiry.reload
-        expect(done_inquiry.notes.last.body).to eq "This is inquiry was not actually finished."
+        expect(done_inquiry.notes.last.body).to eq "This inquiry was not actually finished."
       end
     end
 
@@ -137,7 +137,7 @@ RSpec.describe 'PUT /api/inquiries/:id', type: :request do
 
       it 'is expected to create associated note about when inquiry was set tp pending' do
         started_inquiry.reload
-        expect(started_inquiry.notes.last.body).to eq "This is inquiry was shelved."
+        expect(started_inquiry.notes.last.body).to eq "This inquiry was shelved."
       end
     end
 

--- a/spec/requests/api/inquiries/update_spec.rb
+++ b/spec/requests/api/inquiries/update_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe 'PUT /api/inquiries/:id', type: :request do
   let(:broker_1) { create(:user, email: 'broker@flexcoast.com') }
   let(:credentials) { broker_1.create_new_auth_token }
   let(:broker_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
-  let(:pending_inquiry) { create(:inquiry, inquiry_status: 'pending') }
+  let(:pending_inquiry) { create(:inquiry, inquiry_status: 'pending', email: 'submitter@givemeanoffice.com') }
+  let(:mail_delivery) { ActionMailer::Base.deliveries }
 
   describe 'successfully' do
     describe 'from pending to started' do
@@ -34,6 +35,20 @@ RSpec.describe 'PUT /api/inquiries/:id', type: :request do
       it 'is expected to create associated note about when inquiry was started' do
         pending_inquiry.reload
         expect(pending_inquiry.notes.last.body).to eq "This is inquiry was started."
+      end
+
+      describe 'outgoing email to person that submitted inquiry' do
+        it 'is expected to send email to the inquiry submitter' do
+          expect(mail_delivery[0].to.first).to eq 'submitter@givemeanoffice.com'
+        end
+  
+        it 'is expected to return updated status of inquiry in the subject' do
+          expect(mail_delivery[0].subject).to include("FlexCoast has started processing your inquiry")
+        end
+  
+        it 'is expected to contain message about broker started handling inquiry' do
+          expect(mail_delivery[0].body).to include("We are trying to find you an office right now...idk")
+        end
       end
     end
 

--- a/spec/requests/api/inquiries/update_spec.rb
+++ b/spec/requests/api/inquiries/update_spec.rb
@@ -39,15 +39,15 @@ RSpec.describe 'PUT /api/inquiries/:id', type: :request do
 
       describe 'outgoing email to person that submitted inquiry' do
         it 'is expected to send email to the inquiry submitter' do
-          expect(mail_delivery[0].to.first).to eq 'submitter@givemeanoffice.com'
+          expect(mail_delivery[2].to.first).to eq 'submitter@givemeanoffice.com'
         end
   
         it 'is expected to return updated status of inquiry in the subject' do
-          expect(mail_delivery[0].subject).to include("FlexCoast has started processing your inquiry")
+          expect(mail_delivery[2].subject).to include("FlexCoast has started processing your inquiry")
         end
   
         it 'is expected to contain message about broker started handling inquiry' do
-          expect(mail_delivery[0].body).to include("We are trying to find you an office right now...idk")
+          expect(mail_delivery[2].body).to include("We are trying to find you an office right now...idk")
         end
       end
     end

--- a/spec/requests/api/inquiries/update_spec.rb
+++ b/spec/requests/api/inquiries/update_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'PUT /api/inquiries/:id', type: :request do
         end
   
         it 'is expected to contain message about broker started handling inquiry' do
-          expect(mail_delivery[2].body).to include("We are trying to find you an office right now...idk")
+          expect(mail_delivery[2].body).to include("If you have any questions before I comeback to you. Then you can reach me on broker@flexcoast.com or 031-123-4567")
         end
       end
     end


### PR DESCRIPTION
PT https://www.pivotaltracker.com/story/show/178566960

### User story
```
As Flex Coast
To provide quality customer service
We would like to inform our customers when we have started work on their inquiry
```

### Changes proposed
- When broker starts working on inquiry, an email will be sent to the creator of the inquiry